### PR TITLE
Add ability for Ctrl+A to select all typed text

### DIFF
--- a/iswitchw.ahk
+++ b/iswitchw.ahk
@@ -91,7 +91,7 @@ ControlFocus, Edit1, ahk_id %switcher_id%
 
 Loop
 {
-  Input, input, L1, {enter}{esc}{tab}{backspace}{delete}{up}{down}{left}{right}{home}{end}{F4}
+  Input, input, L1, {enter}{esc}{tab}{backspace}{delete}{up}{down}{left}{right}{home}{end}{F4}{a}
 
   if ErrorLevel = EndKey:enter
   {
@@ -116,6 +116,19 @@ Loop
       ControlSend, SysListView321, {down}, ahk_id %switcher_id%
     }
 
+    continue
+  }
+  else if ErrorLevel = EndKey:a
+  {
+    ControlFocus, Edit1, ahk_id %switcher_id%
+
+    if GetKeyState("Ctrl","P")      
+      chars = {blind}{Home}+{End}
+    else
+      chars := AddModifierKeys("{a}")
+    
+    ControlSend, Edit1, %chars%, ahk_id %switcher_id%
+    
     continue
   }
   else if ErrorLevel = EndKey:backspace


### PR DESCRIPTION
I have `ctrl+a, backspace` in my muscle memory to quickly delete all text I've written. This commit adds that capability for the input box. Handles regular `a` and modifiers using the existing `AddModifierKeys()` function.